### PR TITLE
Add testapp for end to end testing

### DIFF
--- a/end-to-end-testapp/index.html
+++ b/end-to-end-testapp/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+      <title>mParticle Partner Integration Test App</title>
+      <script src="../../../mparticle-sdk-javascript/mparticle.js"></script>
+      <script>mParticle.isDevelopmentMode = true;window.mParticle.isTestEnvironment = true;</script>
+      <script src="../../../../test/end-to-end-testapp/build/compilation.js"></script>
+      <script src="../../../mocha/mocha.js"></script>
+      <script src="./mockhttprequest.js"></script>
+      <script src="./stubbing.js"></script>
+    </head>
+    <body>
+        <h2>mParticle Test App for End to End Testing</h2>
+        Open your console and type in commands such as mParticle.logEvent('testEvent'). In your 'Network' tab, there should be calls to check to see if the there are network calls to your SDK.
+
+        Common event logging methods can be found on our <a href="https://docs.mparticle.com/developers/sdk/javascript/event-tracking/">technical documentation site<a>.
+    </body>
+</html>

--- a/end-to-end-testapp/index.js
+++ b/end-to-end-testapp/index.js
@@ -1,0 +1,2 @@
+require('@mparticle/web-kit-wrapper/index.js');
+require('@mparticle/web-kit-wrapper/end-to-end-testapp/kitConfiguration.js');

--- a/end-to-end-testapp/kitConfiguration.js
+++ b/end-to-end-testapp/kitConfiguration.js
@@ -1,0 +1,26 @@
+var SDKSettings = require('../../../../test/end-to-end-testapp/settings.js');
+var name = require('../../../../integration-builder/initialization.js').name;
+
+var config = {
+    name: name,
+    moduleId: 100, // when published, you will receive a new moduleID
+    isDebug: true,
+    isSandbox: true,
+    settings: SDKSettings,
+    userIdentityFilters: [],
+    hasDebugString: [],
+    isVisible: [],
+    eventNameFilters: [],
+    eventTypeFilters: [],
+    attributeFilters: [],
+    screenNameFilters: [],
+    pageViewAttributeFilters: [],
+    userAttributeFilters: [],
+    filteringEventAttributeValue: 'null',
+    filteringUserAttributeValue: 'null',
+    eventSubscriptionId: 123,
+    filteringConsentRuleValues: 'null',
+    excludeAnonymousUser: false
+};
+
+mParticle.configureForwarder(config);

--- a/end-to-end-testapp/mockhttprequest.js
+++ b/end-to-end-testapp/mockhttprequest.js
@@ -1,0 +1,476 @@
+/*
+ * Mock XMLHttpRequest (see http://www.w3.org/TR/XMLHttpRequest)
+ *
+ * Written by Philipp von Weitershausen <philipp@weitershausen.de>
+ * Released under the MIT license.
+ * http://www.opensource.org/licenses/mit-license.php
+ *
+ * For test interaction it exposes the following attributes:
+ *
+ * - method, url, urlParts, async, user, password
+ * - requestText
+ *
+ * as well as the following methods:
+ *
+ * - getRequestHeader(header)
+ * - setResponseHeader(header, value)
+ * - receive(status, data)
+ * - err(exception)
+ * - authenticate(user, password)
+ *
+ */
+function MockHttpRequest () {
+    // These are internal flags and data structures
+    this.error = false;
+    this.sent = false;
+    this.requestHeaders = {};
+    this.responseHeaders = {};
+}
+MockHttpRequest.prototype = {
+    withCredentials: true,
+
+    statusReasons: {
+        100: 'Continue',
+        101: 'Switching Protocols',
+        102: 'Processing',
+        200: 'OK',
+        201: 'Created',
+        202: 'Accepted',
+        203: 'Non-Authoritative Information',
+        204: 'No Content',
+        205: 'Reset Content',
+        206: 'Partial Content',
+        207: 'Multi-Status',
+        300: 'Multiple Choices',
+        301: 'Moved Permanently',
+        302: 'Moved Temporarily',
+        303: 'See Other',
+        304: 'Not Modified',
+        305: 'Use Proxy',
+        307: 'Temporary Redirect',
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        402: 'Payment Required',
+        403: 'Forbidden',
+        404: 'Not Found',
+        405: 'Method Not Allowed',
+        406: 'Not Acceptable',
+        407: 'Proxy Authentication Required',
+        408: 'Request Time-out',
+        409: 'Conflict',
+        410: 'Gone',
+        411: 'Length Required',
+        412: 'Precondition Failed',
+        413: 'Request Entity Too Large',
+        414: 'Request-URI Too Large',
+        415: 'Unsupported Media Type',
+        416: 'Requested range not satisfiable',
+        417: 'Expectation Failed',
+        422: 'Unprocessable Entity',
+        423: 'Locked',
+        424: 'Failed Dependency',
+        500: 'Internal Server Error',
+        501: 'Not Implemented',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        504: 'Gateway Time-out',
+        505: 'HTTP Version not supported',
+        507: 'Insufficient Storage'
+    },
+
+    /*** State ***/
+
+    UNSENT: 0,
+    OPENED: 1,
+    HEADERS_RECEIVED: 2,
+    LOADING: 3,
+    DONE: 4,
+    readyState: 0,
+
+
+    /*** Request ***/
+
+    open: function (method, url, async, user, password) {
+        var urlParts = url.split('.');
+        window.xhrDomain = urlParts[1];
+
+        if (typeof method !== "string") {
+            throw "INVALID_METHOD";
+        }
+        switch (method.toUpperCase()) {
+        case "CONNECT":
+        case "TRACE":
+        case "TRACK":
+            throw "SECURITY_ERR";
+
+        case "DELETE":
+        case "GET":
+        case "HEAD":
+        case "OPTIONS":
+        case "POST":
+        case "PUT":
+            method = method.toUpperCase();
+        }
+        this.method = method;
+
+        if (typeof url !== "string") {
+            throw "INVALID_URL";
+        }
+        this.url = url;
+        this.urlParts = this.parseUri(url);
+
+        if (async === undefined) {
+            async = true;
+        }
+        this.async = async;
+        this.user = user;
+        this.password = password;
+
+        this.readyState = this.OPENED;
+        this.onreadystatechange();
+    },
+
+    setRequestHeader: function (header, value) {
+        header = header.toLowerCase();
+
+        switch (header) {
+        case "accept-charset":
+        case "accept-encoding":
+        case "connection":
+        case "content-length":
+        case "cookie":
+        case "cookie2":
+        case "content-transfer-encoding":
+        case "date":
+        case "expect":
+        case "host":
+        case "keep-alive":
+        case "referer":
+        case "te":
+        case "trailer":
+        case "transfer-encoding":
+        case "upgrade":
+        case "user-agent":
+        case "via":
+            return;
+        }
+        if ((header.substr(0, 6) === "proxy-")
+            || (header.substr(0, 4) === "sec-")) {
+            return;
+        }
+
+        // it's the first call on this header field
+        if (this.requestHeaders[header] === undefined)
+          this.requestHeaders[header] = value;
+        else {
+          var prev = this.requestHeaders[header];
+          this.requestHeaders[header] = prev + ", " + value;
+        }
+
+    },
+
+    send: function (data) {
+        console.log(data);
+        if ((this.readyState !== this.OPENED)
+            || this.sent) {
+            throw "INVALID_STATE_ERR";
+        }
+        if ((this.method === "GET") || (this.method === "HEAD")) {
+            data = null;
+        }
+        //TODO set Content-Type header?
+        this.error = false;
+        this.sent = true;
+        this.onreadystatechange();
+        // fake send
+        this.requestText = data;
+        // if (window.xhrDomain === 'mparticle') {
+        window.server.stop();
+            // window.serverstatus = 'stopped'
+        // }
+        this.onsend();
+    },
+
+    abort: function () {
+        this.responseText = null;
+        this.error = true;
+        for (var header in this.requestHeaders) {
+            delete this.requestHeaders[header];
+        }
+        delete this.requestText;
+        this.onreadystatechange();
+        this.onabort();
+        this.readyState = this.UNSENT;
+    },
+
+
+    /*** Response ***/
+
+    status: 0,
+    statusText: "",
+
+    getResponseHeader: function (header) {
+        if ((this.readyState === this.UNSENT)
+            || (this.readyState === this.OPENED)
+            || this.error) {
+            return null;
+        }
+        return this.responseHeaders[header.toLowerCase()];
+    },
+
+    getAllResponseHeaders: function () {
+        var r = "";
+        for (var header in this.responseHeaders) {
+            if ((header === "set-cookie") || (header === "set-cookie2")) {
+                continue;
+            }
+            //TODO title case header
+            r += header + ": " + this.responseHeaders[header] + "\r\n";
+        }
+        return r;
+    },
+
+    responseText: "",
+    responseXML: undefined, //TODO
+
+
+    /*** See http://www.w3.org/TR/progress-events/ ***/
+
+    onload: function () {
+        // Instances should override this.
+    },
+
+    onprogress: function () {
+        // Instances should override this.
+    },
+
+    onerror: function () {
+        // Instances should override this.
+    },
+
+    onabort: function () {
+        // Instances should override this.
+    },
+
+    onreadystatechange: function () {
+        // Instances should override this.
+    },
+
+
+    /*** Properties and methods for test interaction ***/
+
+    onsend: function () {
+    },
+
+    getRequestHeader: function (header) {
+        return this.requestHeaders[header.toLowerCase()];
+    },
+
+    setResponseHeader: function (header, value) {
+        this.responseHeaders[header.toLowerCase()] = value;
+    },
+
+    makeXMLResponse: function (data) {
+        var xmlDoc;
+        // according to specs from point 3.7.5:
+        // "1. If the response entity body is null terminate these steps
+        //     and return null.
+        //  2. If final MIME type is not null, text/xml, application/xml,
+        //     and does not end in +xml terminate these steps and return null.
+        var mimetype = this.getResponseHeader("Content-Type");
+        mimetype = mimetype && mimetype.split(';', 1)[0];
+        if ((mimetype == null) || (mimetype == 'text/xml') ||
+           (mimetype == 'application/xml') ||
+           (mimetype && mimetype.substring(mimetype.length - 4) == '+xml')) {
+            // Attempt to produce an xml response
+            // and it will fail if not a good xml
+            try {
+                if (window.DOMParser) {
+                    var parser = new DOMParser();
+                    xmlDoc = parser.parseFromString(data, "text/xml");
+                } else { // Internet Explorer
+                    xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
+                    xmlDoc.async = "false";
+                    xmlDoc.loadXML(data);
+                }
+            } catch (e) {
+                // according to specs from point 3.7.5:
+                // "3. Let document be a cookie-free Document object that
+                // represents the result of parsing the response entity body
+                // into a document tree following the rules from the XML
+                //  specifications. If this fails (unsupported character
+                // encoding, namespace well-formedness error etc.), terminate
+                // these steps return null."
+                xmlDoc = null;
+            }
+            // parse errors also yield a null.
+            if ((xmlDoc && xmlDoc.parseError && xmlDoc.parseError.errorCode != 0)
+                || (xmlDoc && xmlDoc.documentElement && xmlDoc.documentElement.nodeName == "parsererror")
+                || (xmlDoc && xmlDoc.documentElement && xmlDoc.documentElement.nodeName == "html"
+                    &&  xmlDoc.documentElement.firstChild &&  xmlDoc.documentElement.firstChild.nodeName == "body"
+                    &&  xmlDoc.documentElement.firstChild.firstChild && xmlDoc.documentElement.firstChild.firstChild.nodeName == "parsererror")) {
+                xmlDoc = null;
+            }
+        } else {
+            // mimetype is specified, but not xml-ish
+            xmlDoc = null;
+        }
+        return xmlDoc;
+    },
+
+    // Call this to simulate a server response
+    receive: function (status, data) {
+        if ((this.readyState !== this.OPENED) || (!this.sent)) {
+            // Can't respond to unopened request.
+            throw "INVALID_STATE_ERR";
+        }
+
+        this.status = status;
+        this.statusText = status + " " + this.statusReasons[status];
+        this.readyState = this.HEADERS_RECEIVED;
+        this.onprogress();
+        this.onreadystatechange();
+
+        this.responseText = data;
+        this.responseXML = this.makeXMLResponse(data);
+
+        this.readyState = this.LOADING;
+        this.onprogress();
+        this.onreadystatechange();
+
+        this.readyState = this.DONE;
+        this.onreadystatechange();
+        this.onprogress();
+        this.onload();
+    },
+
+    // Call this to simulate a request error (e.g. NETWORK_ERR)
+    err: function (exception) {
+        if ((this.readyState !== this.OPENED) || (!this.sent)) {
+            // Can't respond to unopened request.
+            throw "INVALID_STATE_ERR";
+        }
+
+        this.responseText = null;
+        this.error = true;
+        for (var header in this.requestHeaders) {
+            delete this.requestHeaders[header];
+        }
+        this.readyState = this.DONE;
+        if (!this.async) {
+            throw exception;
+        }
+        this.onreadystatechange();
+        this.onerror();
+    },
+
+    // Convenience method to verify HTTP credentials
+    authenticate: function (user, password) {
+        if (this.user) {
+            return (user === this.user) && (password === this.password);
+        }
+
+        if (this.urlParts.user) {
+            return ((user === this.urlParts.user)
+                    && (password === this.urlParts.password));
+        }
+
+        // Basic auth.  Requires existence of the 'atob' function.
+        var auth = this.getRequestHeader("Authorization");
+        if (auth === undefined) {
+            return false;
+        }
+        if (auth.substr(0, 6) !== "Basic ") {
+            return false;
+        }
+        if (typeof atob !== "function") {
+            return false;
+        }
+        auth = atob(auth.substr(6));
+        var pieces = auth.split(':');
+        var requser = pieces.shift();
+        var reqpass = pieces.join(':');
+        return (user === requser) && (password === reqpass);
+    },
+
+    // Parse RFC 3986 compliant URIs.
+    // Based on parseUri by Steven Levithan <stevenlevithan.com>
+    // See http://blog.stevenlevithan.com/archives/parseuri
+    parseUri: function (str) {
+        var pattern = /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/;
+        var key = ["source", "protocol", "authority", "userInfo", "user",
+                   "password", "host", "port", "relative", "path",
+                   "directory", "file", "query", "anchor"];
+        var querypattern = /(?:^|&)([^&=]*)=?([^&]*)/g;
+
+        var match = pattern.exec(str);
+		var uri = {};
+		var i = 14;
+	    while (i--) {
+            uri[key[i]] = match[i] || "";
+        }
+
+	    uri.queryKey = {};
+	    uri[key[12]].replace(querypattern, function ($0, $1, $2) {
+		    if ($1) {
+                uri.queryKey[$1] = $2;
+            }
+	    });
+
+	    return uri;
+    }
+};
+
+
+/*
+ * A small mock "server" that intercepts XMLHttpRequest calls and
+ * diverts them to your handler.
+ *
+ * Usage:
+ *
+ * 1. Initialize with either
+ *       var server = new MockHttpServer(your_request_handler);
+ *    or
+ *       var server = new MockHttpServer();
+ *       server.handle = function (request) { ... };
+ *
+ * 2. Call server.start() to start intercepting all XMLHttpRequests.
+ *
+ * 3. Do your tests.
+ *
+ * 4. Call server.stop() to tear down.
+ *
+ * 5. Profit!
+ */
+function MockHttpServer (handler) {
+    if (handler) {
+        this.handle = handler;
+    }
+};
+MockHttpServer.prototype = {
+    requests: [],
+    start: function () {
+        var self = this;
+
+        function Request () {
+            this.onsend = function () {
+                self.requests.push(this);
+                self.handle(this);
+            };
+            MockHttpRequest.apply(this, arguments);
+        }
+        Request.prototype = MockHttpRequest.prototype;
+        window.OriginalHttpRequest = window.XMLHttpRequest;
+        window.XMLHttpRequest = Request;
+    },
+
+    stop: function () {
+        window.XMLHttpRequest = window.OriginalHttpRequest;
+    },
+
+    handle: function (request) {
+        // Instances should override this.
+    }
+};
+
+module.exports = MockHttpServer

--- a/end-to-end-testapp/server.js
+++ b/end-to-end-testapp/server.js
@@ -1,0 +1,9 @@
+var express = require('express');
+var app = express();
+var path = require('path');
+
+app.use(express.static(path.join(__dirname, '../../../../')));
+module.exports = app;
+var server = app.listen(8082, function() {
+    console.log('express server listening on port ' + server.address().port);
+});

--- a/end-to-end-testapp/stubbing.js
+++ b/end-to-end-testapp/stubbing.js
@@ -1,0 +1,47 @@
+window.server = new MockHttpServer;
+window.server.requests = [];
+window.server.handle = function(request) {
+    request.setResponseHeader('Content-Type', 'application/json');
+    request.receive(200, JSON.stringify({
+        Store: {},
+        mpid: 'testMPID'
+    }));
+};
+
+var mParticleKeys = ['startNewSession', 'endSession', 'init', 'logError', 'logEvent', 'logForm', 'logLink', 'logPageView', 'setOptOut'];
+var mParticleIdentityKeys = ['identify', 'login', 'logout', 'modify'];
+var mParticleEcommerceKeys = ['logCheckout', 'logImpression', 'logProductAction', 'logPromotion', 'logPurchase', 'logRefund'];
+var mParticleEcommerceCartKeys = ['add', 'remove'];
+
+
+mParticleKeys.forEach(function(key){
+    replaceFunction(mParticle, key);
+});
+
+mParticleIdentityKeys.forEach(function(key){
+    replaceFunction(mParticle.Identity, key);
+});
+
+mParticleEcommerceKeys.forEach(function(key){
+    replaceFunction(mParticle.eCommerce, key);
+});
+
+mParticleEcommerceCartKeys.forEach(function(key){
+    replaceFunction(mParticle.eCommerce.Cart, key);
+});
+
+mParticle.init('testAPIKey');
+
+function replaceFunction(object, key) {
+    if (typeof object[key] === 'function') {
+        var originalMethod = object[key];
+        object[key] = function() {
+            startMockServer();
+            originalMethod.apply(this, arguments);
+        };
+    }
+}
+
+function startMockServer() {
+    server.start();
+}

--- a/index.js
+++ b/index.js
@@ -43,7 +43,12 @@ var UserAttributeHandler = require('../../../integration-builder/user-attribute-
 
         function initForwarder(settings, service, testMode, trackerId, userAttributes, userIdentities) {
             forwarderSettings = settings;
-            reportingService = service;
+            if (window.mParticle.isTestEnvironment) {
+                reportingService = function() {
+                };
+            } else {
+                reportingService = service;
+            }
 
             try {
                 Initialization.initForwarder(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized);


### PR DESCRIPTION
Adding the full test app to wrapper here. Want to point out a few things:

* e2dtestapp/index.js - this compiles the integration and the configuration into a single file `compilation.js` which is pulled into the index.html file
* kitConfiguration.js - boilerplate for the configureForwarder call.  `require`s the SDK settings in the integration builder found [here](https://github.com/mparticle-integrations/mparticle-javascript-integration-example/compare/add-test-app?expand=1#diff-7154d8fecd1f32ba0b9653b0f6e0ce97)
* stubbing.js - replaces each method that makes an api call on mParticle to start a mock server to hijack the api call to our server. mockhttprequest.js has been updated so that after the mParticle event is sent to us, it stops the server, and then the forwarder event is then sent to the partner SDK so that they can verify the network request is correct and view it on their dashboard if applicable
* updated index.js to account for hijacking the forwarding call if we are in the test environment, which is set in the e2etestapp/index.html file.