### PR TITLE
Refactor to support instance configurations

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,9 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
             try {
                 Initialization.initForwarder(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, self.common);
                 self.eventHandler = new EventHandler(self.common);
+                self.identityHandler = new IdentityHandler(self.common);
+                self.userAttributeHandler = new UserAttributeHandler(self.common);
+                self.commerceHandler = new CommerceHandler(self.common);
 
                 isInitialized = true;
             } catch (e) {
@@ -147,7 +150,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
 
         function logEcommerceEvent(event) {
             try {
-                CommerceHandler.logCommerceEvent(event);
+                self.commerceHandler.logCommerceEvent(event);
                 return true;
             } catch (e) {
                 return {error: 'Error logging purchase event on forwarder ' + name + '; ' + e};
@@ -157,7 +160,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function setUserAttribute(key, value) {
             if (isInitialized) {
                 try {
-                    UserAttributeHandler.onSetUserAttribute(key, value, forwarderSettings);
+                    self.userAttributeHandler.onSetUserAttribute(key, value, forwarderSettings);
                     return 'Successfully set user attribute on forwarder ' + name;
                 } catch (e) {
                     return 'Error setting user attribute on forwarder ' + name + '; ' + e;
@@ -170,7 +173,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function removeUserAttribute(key) {
             if (isInitialized) {
                 try {
-                    UserAttributeHandler.onRemoveUserAttribute(key, forwarderSettings);
+                    self.userAttributeHandler.onRemoveUserAttribute(key, forwarderSettings);
                     return 'Successfully removed user attribute on forwarder ' + name;
                 } catch (e) {
                     return 'Error removing user attribute on forwarder ' + name + '; ' + e;
@@ -183,7 +186,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function setUserIdentity(id, type) {
             if (isInitialized) {
                 try {
-                    IdentityHandler.onSetUserIdentity(forwarderSettings, id, type);
+                    self.identityHandler.onSetUserIdentity(forwarderSettings, id, type);
                     return 'Successfully set user Identity on forwarder ' + name;
                 } catch (e) {
                     return 'Error removing user attribute on forwarder ' + name + '; ' + e;
@@ -197,7 +200,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function onUserIdentified(user) {
             if (isInitialized) {
                 try {
-                    IdentityHandler.onUserIdentified(user);
+                    self.identityHandler.onUserIdentified(user);
 
                     return 'Successfully called onUserIdentified on forwarder ' + name;
                 } catch (e) {
@@ -212,11 +215,11 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function onIdentifyComplete(user, filteredIdentityRequest) {
             if (isInitialized) {
                 try {
-                    IdentityHandler.onIdentifyCompleted(user, filteredIdentityRequest);
+                    self.identityHandler.onIdentifyComplete(user, filteredIdentityRequest);
 
-                    return 'Successfully called onIdentifyCompleted on forwarder ' + name;
+                    return 'Successfully called onIdentifyComplete on forwarder ' + name;
                 } catch (e) {
-                    return {error: 'Error calling onIdentifyCompleted on forwarder ' + name + '; ' + e};
+                    return {error: 'Error calling onIdentifyComplete on forwarder ' + name + '; ' + e};
                 }
             }
             else {
@@ -227,7 +230,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function onLoginComplete(user, filteredIdentityRequest) {
             if (isInitialized) {
                 try {
-                    IdentityHandler.onLoginComplete(user, filteredIdentityRequest);
+                    self.identityHandler.onLoginComplete(user, filteredIdentityRequest);
 
                     return 'Successfully called onLoginComplete on forwarder ' + name;
                 } catch (e) {
@@ -242,7 +245,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function onLogoutComplete(user, filteredIdentityRequest) {
             if (isInitialized) {
                 try {
-                    IdentityHandler.onLogoutComplete(user, filteredIdentityRequest);
+                    self.identityHandler.onLogoutComplete(user, filteredIdentityRequest);
 
                     return 'Successfully called onLogoutComplete on forwarder ' + name;
                 } catch (e) {
@@ -257,7 +260,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function onModifyComplete(user, filteredIdentityRequest) {
             if (isInitialized) {
                 try {
-                    IdentityHandler.onModifyComplete(user, filteredIdentityRequest);
+                    self.identityHandler.onModifyComplete(user, filteredIdentityRequest);
 
                     return 'Successfully called onModifyComplete on forwarder ' + name;
                 } catch (e) {
@@ -272,7 +275,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         function setOptOut(isOptingOutBoolean) {
             if (isInitialized) {
                 try {
-                    Initialization.setOptOut(isOptingOutBoolean);
+                    self.initialization.setOptOut(isOptingOutBoolean);
 
                     return 'Successfully called setOptOut on forwarder ' + name;
                 } catch (e) {

--- a/index.js
+++ b/index.js
@@ -295,8 +295,6 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         this.onLogoutComplete = onLogoutComplete;
         this.onModifyComplete = onModifyComplete;
         this.setOptOut = setOptOut;
-
-        this.common = new Common();
     };
 
     if (!window || !window.mParticle || !window.mParticle.addForwarder) {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+
+var Common = require('../../../src/common');
 var CommerceHandler = require('../../../src/commerce-handler');
 var EventHandler = require('../../../src/event-handler');
 var IdentityHandler = require('../../../src/identity-handler');
@@ -40,9 +42,11 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
             eventQueue = [];
 
         self.name = Initialization.name;
+        self.common = new Common();
 
         function initForwarder(settings, service, testMode, trackerId, userAttributes, userIdentities) {
             forwarderSettings = settings;
+
             if (window.mParticle.isTestEnvironment) {
                 reportingService = function() {
                 };
@@ -51,7 +55,9 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
             }
 
             try {
-                Initialization.initForwarder(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized);
+                Initialization.initForwarder(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, self.common);
+                self.eventHandler = new EventHandler(self.common);
+
                 isInitialized = true;
             } catch (e) {
                 console.log('Failed to initialize ' + name + ' - ' + e);
@@ -114,7 +120,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
 
         function logError(event) {
             try {
-                EventHandler.logError(event);
+                self.eventHandler.logError(event);
                 return true;
             } catch (e) {
                 return {error: 'Error logging error on forwarder ' + name + '; ' + e};
@@ -123,7 +129,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
 
         function logPageView(event) {
             try {
-                EventHandler.logPageView(event);
+                self.eventHandler.logPageView(event);
                 return true;
             } catch (e) {
                 return {error: 'Error logging page view on forwarder ' + name + '; ' + e};
@@ -132,7 +138,7 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
 
         function logEvent(event) {
             try {
-                EventHandler.logEvent(event);
+                self.eventHandler.logEvent(event);
                 return true;
             } catch (e) {
                 return {error: 'Error logging event on forwarder ' + name + '; ' + e};
@@ -289,6 +295,8 @@ var UserAttributeHandler = require('../../../src/user-attribute-handler');
         this.onLogoutComplete = onLogoutComplete;
         this.onModifyComplete = onModifyComplete;
         this.setOptOut = setOptOut;
+
+        this.common = new Common();
     };
 
     if (!window || !window.mParticle || !window.mParticle.addForwarder) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-kit-wrapper",
-  "version": "1.0.0-rc5",
+  "version": "1.0.0-rc6",
   "description": "mParticle wrapper for web kit integrations",
   "main": "index.js",
   "unpkg": "@mparticle/web-kit-wrapper.js",


### PR DESCRIPTION
In cases where we are using multiple instances of the "same" kit,
each instance should maintain its own configuration. For example,
Google Tag Manager should support its own dataLayer variable name
and this should be unique to each instance.

The current implementation will overwrite common with the latest
configuration and will not be unique across mutliple instances.