### PR TITLE
Add testEndToEnd build to rollup to be used by js integration builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 --
 
-#### 1.0.13 - 2020-02-11
+#### 1.0.4 - 2020-02-25
+
+-   Update rollup config file to provide a testEndToEnd build file for consumption by [JS integration example builder](https://github.com/mparticle-integrations/mparticle-javascript-integration-example/)
+
+#### 1.0.3 - 2020-02-11
 
 -   Bugfix - Remove duplicate addForwarder reference
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-kit-wrapper",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -191,11 +191,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
-    },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-kit-wrapper",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "mParticle wrapper for web kit integrations",
   "main": "index.js",
   "unpkg": "@mparticle/web-kit-wrapper.js",

--- a/rollup.base.js
+++ b/rollup.base.js
@@ -1,16 +1,30 @@
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 
-export default {
+const plugins = [
+    resolve({
+        browser: true,
+    }),
+    commonjs(),
+];
+
+const production = {
     input: './node_modules/@mparticle/web-kit-wrapper/index.js',
     output: {
         exports: 'named',
         strict: true,
     },
-    plugins: [
-        resolve({
-            browser: true,
-        }),
-        commonjs(),
-    ],
+    plugins: plugins,
 };
+
+const testEndToEnd = {
+    input:
+        './node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.js',
+    output: {
+        exports: 'named',
+        strict: true,
+    },
+    plugins: plugins,
+};
+
+export { production, testEndToEnd };


### PR DESCRIPTION
Browserify was still being used by integration builder in order to test a partner made kit end to end.

Removing that from the integration-builder ([PR here](https://github.com/mparticle-integrations/mparticle-javascript-integration-example/pull/11)), requires a `testEndToEnd` option to be available on the wrapper.