### PR TITLE
Add additional arguments to initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,11 @@ var constructor = function() {
         testMode,
         trackerId,
         userAttributes,
-        userIdentities
+        userIdentities,
+        appVersion,
+        appName,
+        customFlags,
+        clientId
     ) {
         forwarderSettings = settings;
 
@@ -71,7 +75,11 @@ var constructor = function() {
                 processEvent,
                 eventQueue,
                 isInitialized,
-                self.common
+                self.common,
+                appVersion,
+                appName,
+                customFlags,
+                clientId
             );
             self.eventHandler = new EventHandler(self.common);
             self.identityHandler = new IdentityHandler(self.common);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-kit-wrapper",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-kit-wrapper",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "mParticle wrapper for web kit integrations",
   "main": "index.js",
   "unpkg": "@mparticle/web-kit-wrapper.js",


### PR DESCRIPTION
When core sdk [initializes each forwarder](https://github.com/mParticle/mparticle-web-sdk/blob/master/src/forwarders.js#L58-L68), it passes several arguments that the wrapper for new kits is missing.  This PR adds these additional arguments to the wrapper.