### PR TITLE
fix: Prevent logging events from always returning true

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,8 +139,7 @@ var constructor = function() {
 
     function logSessionStart(event) {
         try {
-            SessionHandler.onSessionStart(event);
-            return true;
+            return SessionHandler.onSessionStart(event);
         } catch (e) {
             return {
                 error: 'Error starting session on forwarder ' + name + '; ' + e,
@@ -150,8 +149,7 @@ var constructor = function() {
 
     function logSessionEnd(event) {
         try {
-            SessionHandler.onSessionEnd(event);
-            return true;
+            return SessionHandler.onSessionEnd(event);
         } catch (e) {
             return {
                 error: 'Error ending session on forwarder ' + name + '; ' + e,
@@ -161,8 +159,7 @@ var constructor = function() {
 
     function logError(event) {
         try {
-            self.eventHandler.logError(event);
-            return true;
+            return self.eventHandler.logError(event);
         } catch (e) {
             return {
                 error: 'Error logging error on forwarder ' + name + '; ' + e,
@@ -172,8 +169,7 @@ var constructor = function() {
 
     function logPageView(event) {
         try {
-            self.eventHandler.logPageView(event);
-            return true;
+            return self.eventHandler.logPageView(event);
         } catch (e) {
             return {
                 error:
@@ -184,8 +180,7 @@ var constructor = function() {
 
     function logEvent(event) {
         try {
-            self.eventHandler.logEvent(event);
-            return true;
+            return self.eventHandler.logEvent(event);
         } catch (e) {
             return {
                 error: 'Error logging event on forwarder ' + name + '; ' + e,
@@ -195,8 +190,7 @@ var constructor = function() {
 
     function logEcommerceEvent(event) {
         try {
-            self.commerceHandler.logCommerceEvent(event);
-            return true;
+            return self.commerceHandler.logCommerceEvent(event);
         } catch (e) {
             return {
                 error:


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
All of our `logX` methods would first call `self.eventHandler.logX`, and then `return true`.   This results in always returning true even if the `self.eventHandler.logX` returns `false`.  We should return the boolean that `self.eventHandler.logX` returns, which comes from a kit.  

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
I imported this file locally in the GMP kit and re-built the GMP kit.  Previously, the kit would return `false` to the wrapper, but the wrapper would still call the `reportingService` because it ignores the `false` that the kid returns.  Now that we return the boolean that `self.eventHandler.logX` returns, this works as expected.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5783
